### PR TITLE
Provide AppStream metainfo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,11 @@ install-data-local:
 		mkdir -p $(DESTDIR)$(datadir)/bash-completion/completions; \
 	fi
 	$(INSTALL_DATA) atomes-completion.sh $(DESTDIR)$(datadir)/bash-completion/completions/atomes
+	if [ ! -d $(DESTDIR)$(datadir)/metainfo ]; then \
+		mkdir -p $(DESTDIR)$(datadir)/metainfo; \
+	fi
+	$(INSTALL_DATA) fr.ipcms.atomes.atomes.metainfo.xml $(DESTDIR)$(datadir)/metainfo
+	appstream-util validate-relax --nonet $(DESTDIR)$(datadir)/metainfo/fr.ipcms.atomes.atomes.metainfo.xml
 	sed 's;DATADIR;$(pkgdatadir);1' $(srcdir)/atomes.desktop.in > $(srcdir)/atomes.desktop
 	$(INSTALL_DATA) $(srcdir)/atomes.desktop $(DESTDIR)$(pkgdatadir)
 	if [ ! -d $(DESTDIR)$(datadir)/applications ]; then \
@@ -98,6 +103,7 @@ uninstall-local:
 	-rm -f $(DESTDIR)$(atomes_mandir)/man1/atomes.*
 	-rm -f $(DESTDIR)$(datadir)/applications/atomes.desktop
 	-rm -f $(DESTDIR)$(datadir)/bash-completion/completion/atomes
+	-rm -f $(DESTDIR)$(datadir)/metainfo/fr.ipcms.atomes.atomes.metainfo.xml
 	update-mime-database $(DESTDIR)$(datadir)/mime &> /dev/null || :
 	update-desktop-database &> /dev/null || :
 	touch --no-create $(DESTDIR)$(datadir)/icons/hicolor

--- a/Makefile.in
+++ b/Makefile.in
@@ -946,6 +946,11 @@ install-data-local:
 		mkdir -p $(DESTDIR)$(datadir)/bash-completion/completions; \
 	fi
 	$(INSTALL_DATA) atomes-completion.sh $(DESTDIR)$(datadir)/bash-completion/completions/atomes
+	if [ ! -d $(DESTDIR)$(datadir)/metainfo ]; then \
+		mkdir -p $(DESTDIR)$(datadir)/metainfo; \
+	fi
+	$(INSTALL_DATA) fr.ipcms.atomes.atomes.metainfo.xml $(DESTDIR)$(datadir)/metainfo
+	appstream-util validate-relax --nonet $(DESTDIR)$(datadir)/metainfo/fr.ipcms.atomes.atomes.metainfo.xml
 	sed 's;DATADIR;$(pkgdatadir);1' $(srcdir)/atomes.desktop.in > $(srcdir)/atomes.desktop
 	$(INSTALL_DATA) $(srcdir)/atomes.desktop $(DESTDIR)$(pkgdatadir)
 	if [ ! -d $(DESTDIR)$(datadir)/applications ]; then \
@@ -977,6 +982,7 @@ uninstall-local:
 	-rm -f $(DESTDIR)$(atomes_mandir)/man1/atomes.*
 	-rm -f $(DESTDIR)$(datadir)/applications/atomes.desktop
 	-rm -f $(DESTDIR)$(datadir)/bash-completion/completion/atomes
+	-rm -f $(DESTDIR)$(datadir)/metainfo/fr.ipcms.atomes.atomes.metainfo.xml
 	update-mime-database $(DESTDIR)$(datadir)/mime &> /dev/null || :
 	update-desktop-database &> /dev/null || :
 	touch --no-create $(DESTDIR)$(datadir)/icons/hicolor

--- a/fr.ipcms.atomes.atomes.metainfo.xml
+++ b/fr.ipcms.atomes.atomes.metainfo.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Sébastien Le Roux -->
+<component type="desktop-application">
+  <id>fr.ipcms.atomes.atomes</id>
+  
+  <name>Atomes</name>
+  <summary>An atomistic toolbox</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+  
+  <description>
+    <p>
+      Atomes: a toolbox to analyze, to visualize  and to create/edit three-dimensional atomistic models. It offers a workspace that allows to have many projects opened simultaneously. The different projects in the workspace can exchange data:  analysis results, atomic coordinates... Atomes also provides an advanced input preparation system  for further calculations using well known molecular dynamics codes:
+    </p>
+    <p>
+      Classical MD: DLPOLY and LAMMPS
+    </p>
+    <p>
+      ab-initio MD: CPMD and CP2K
+    </p>
+    <p>
+      QM-MM MD: CPMD and CP2K
+    </p>
+    <p>
+      To prepare the input files for these calculations is likely to be the key,  and most complicated step towards MD simulations. Atomes offers a user-friendly assistant to help and guide the scientist step by step to achieve this crucial step.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">atomes.desktop</launchable>
+  
+  <screenshots>
+    <screenshot type="default">
+      <image>https://atomes.ipcms.fr/wp-content/uploads/2022/08/Ni-Phth-1024x512.jpeg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://atomes.ipcms.fr/wp-content/uploads/2022/08/lGeSe-1024x625.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://atomes.ipcms.fr/wp-content/uploads/2022/08/workm2-1024x647.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <url type="homepage">https://atomes.ipcms.fr/</url>
+  <developer_name>Dr. Sébastien Le Roux</developer_name>
+  <update_contact>atomes_AT_ipcms.unistra.fr</update_contact>
+  
+  <provides>
+    <binary>atomes</binary>
+  </provides>
+  
+  <content_rating type="oars-1.1" />
+  
+  <releases>
+    <release version="1.1.6" date="2022-10-12">
+      <description>
+        <p>
+          <ul>
+            <li>
+              Bug correction:
+              w_library.c: lib_preview_plot = NULL;
+            </li>
+            <li>
+              Improvements: 
+              main.c: -h
+              glview.c: selection delay on mouse pressed/released
+            </li>
+          </ul>
+        </p>
+      </description>
+    </release>
+  </releases>
+  
+</component>


### PR DESCRIPTION
You may want to check the sanity of the directives in the Makefiles.

You will need to provide some screenshots, have a look at the documentation:
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-screenshots-info

In order to capture the entire application window at a 16:9 ratio, there is a handy GNOME extension:
https://extensions.gnome.org/extension/881/screenshot-window-sizer/

You can host the screenshots wherever you like or on your github. In that case, assuming you have put them in a "screenshots" directory, named as "Screen1.png", "Screen2,.png", etc., the URL would look something like this:
https://github.com/Slookeur/Atomes/raw/master/screenshots/Screen1.png
